### PR TITLE
Add auto type support to remove dependency among tests

### DIFF
--- a/src/test/java/com/alibaba/fastjson/serializer/TestParse.java
+++ b/src/test/java/com/alibaba/fastjson/serializer/TestParse.java
@@ -2,6 +2,7 @@ package com.alibaba.fastjson.serializer;
 
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.parser.ParserConfig;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -16,9 +17,12 @@ public class TestParse {
 
     private String jsonString;
 
+    private final ParserConfig parserConfig = new ParserConfig();
+
     @Before
     public void prepareJsonString() {
         TestBean bean = new TestBean();
+        parserConfig.setAutoTypeSupport(true);
         bean.setName("tester");
         JSONObject data = new JSONObject();
         data.put("key", "value");
@@ -29,7 +33,7 @@ public class TestParse {
     @Test
     public void testParse() {
         logger.info("parsing json string:" + jsonString);
-        TestBean testBean = (TestBean) JSON.parse(jsonString);
+        TestBean testBean = (TestBean) JSON.parse(jsonString, parserConfig);
         assert testBean.getData() != null;
         assert "tester".equals(testBean.getName());
         assert "value".equals(testBean.getData().getString("key"));


### PR DESCRIPTION
The test `com.alibaba.fastjson.serializer.TestParse.testParse` fails when run standalone or if it is run before `com.alibaba.json.bvt.support.spring.FastJsonRedisSerializerTest.test_6`. This PR removes such a dependency.

### Steps to reproduce

1. Create a custom test suite `CustomTestSuite.java` and change `pom.xml` to just run this using `mvn test`. Changes can be pulled from the following branch [test-setup](https://github.com/rRajivramachandran/fastjson/commit/62aac18f67c08758c2112e13f70ada41229c3dc4).
2. `mvn test`
3. Reverse order in test suite and run `mvn test` again
4. To see the test fail independently run `mvn test -Dtest=com.alibaba.fastjson.serializer.TestParse#testParse`


### Issue and root cause
The following are the logs when `TestParse` is run before `FastJsonRedisSerializerTest`
```
[INFO] Running com.alibaba.fastjson.serializer.CustomSuiteTest
Nov 05, 2023 6:56:36 PM com.alibaba.fastjson.serializer.TestParse testParse
INFO: parsing json string:{"@type":"com.alibaba.fastjson.serializer.TestBean","data":{"@type":"com.alibaba.fastjson.JSONObject","key":"value"},"name":"tester"}
[ERROR] Tests run: 7, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 1.889 s <<< FAILURE! - in com.alibaba.fastjson.serializer.CustomSuiteTest
[ERROR] com.alibaba.fastjson.serializer.TestParse.testParse  Time elapsed: 1.171 s  <<< ERROR!
com.alibaba.fastjson.JSONException: autoType is not support. com.alibaba.fastjson.serializer.TestBean
	at com.alibaba.fastjson.serializer.TestParse.testParse(TestParse.java:37)
```


However when the order of test classes are reversed, it passes:
```
Running com.alibaba.fastjson.serializer.CustomSuiteTest
Nov 05, 2023 7:00:36 PM com.alibaba.fastjson.serializer.TestParse testParse
INFO: parsing json string:{"@type":"com.alibaba.fastjson.serializer.TestBean","data":{"@type":"com.alibaba.fastjson.JSONObject","key":"value"},"name":"tester"}
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.712 s - in com.alibaba.fastjson.serializer.CustomSuiteTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
```

This happens because a `TestBean` class object is created and serialized producing an automatic type as indicated in the logs `parsing json string:{"@type":"com.alibaba.fastjson.serializer.TestBean","data":{"@type":"com.alibaba.fastjson.JSONObject","key":"value"},"name":"tester"}` during the run of `TestParse`. This string is attempted to be deserialized at [TestParse](https://github.com/rRajivramachandran/fastjson/blob/c942c83443117b73af5ad278cc780270998ba3e1/src/test/java/com/alibaba/fastjson/serializer/TestParse.java#L32). Due to security reasons, deserialization of auto type is set as a configurable flag, and if it is not enabled, the above seen error occurs [ParserConfig](https://github.com/rRajivramachandran/fastjson/blob/c942c83443117b73af5ad278cc780270998ba3e1/src/main/java/com/alibaba/fastjson/parser/ParserConfig.java#L1459). The [FastJsonRedisSerializerTest](https://github.com/rRajivramachandran/fastjson/blob/c942c83443117b73af5ad278cc780270998ba3e1/src/test/java/com/alibaba/json/bvt/support/spring/FastJsonRedisSerializerTest.java#L70) sets this property on the global instance. The same global instance gets used when `TestParse` is run after it because it does not pass any config while calling `JSON.parse()`. This is the reason the test passes. 

### Fix:
To remove this dependency and not create any more dependencies, the flag is set on a local config object created for this test. This `ParseConfig` object is explicitly passed for deserialization.

### Verification of fix:
Test passes when run standalone. (`mvn test -Dtest=com.alibaba.fastjson.serializer.TestParse#testParse`)