### PR TITLE
Fix flaky test by adding time comparision granularity

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/issue_2700/Issue2784.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2700/Issue2784.java
@@ -6,6 +6,7 @@ import junit.framework.TestCase;
 
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
 public class Issue2784 extends TestCase {
@@ -18,7 +19,7 @@ public class Issue2784 extends TestCase {
                 + "}", str);
 
         Model m1 = JSON.parseObject(str, Model.class);
-        assertEquals(m.time, m1.time);
+        assertEquals(m.time.truncatedTo(ChronoUnit.MILLIS), m1.time.truncatedTo(ChronoUnit.MILLIS));
     }
 
     public void test_for_issue_1() throws Exception {


### PR DESCRIPTION
### System Settings
Java: 11.0.20.1
Maven: 3.8.8

### Test failure Reproduction

Command: `mvn -pl . test -Dtest=com.alibaba.json.bvt.issue_2700.Issue2784#test_for_issue`

```
[INFO] Running com.alibaba.json.bvt.issue_2700.Issue2784
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.889 s <<< FAILURE! - in com.alibaba.json.bvt.issue_2700.Issue2784
[ERROR] com.alibaba.json.bvt.issue_2700.Issue2784.test_for_issue  Time elapsed: 0.531 s  <<< FAILURE!
junit.framework.AssertionFailedError: expected:<2023-11-11T11:38:15.749028> but was:<2023-11-11T11:38:15.749>
at com.alibaba.json.bvt.issue_2700.Issue2784.test_for_issue(Issue2784.java:21)
```
### Root Cause

The issue arises because the serialization and de serialization for `Model` class defines milliseconds as the granularity [here](https://github.com/alibaba/fastjson/blob/c942c83443117b73af5ad278cc780270998ba3e1/src/test/java/com/alibaba/json/bvt/issue_2700/Issue2784.java#L107). However for the other object under comparision the exact system time [`java.time.LocalDateTime`](https://docs.oracle.com/javase/8/docs/api/java/time/LocalDateTime.html)(upto nanoseconds precision) is considered. The test will only pass when the system time taken is an exact millisecond value(i.e microsecond and nanoseconds are zero). The pass scenario has been verified using the following [patch](https://github.com/alibaba/fastjson/commit/6146f53ddb219094e097017391c21c1b6b84b1ee#diff-589f95c6f4c1a84052cc74f5c9e3223eb19ecf57387b23a6b347021044a55d58)

### Fix
Compare the objects only upto millisecond granularity as this is the level of precision defined in the model.

### Verification of fix
The test passes without any other changes